### PR TITLE
Added COPY_ARTIFACTS environment to indicate copying artifacts from parent job

### DIFF
--- a/build-wrapper.sh
+++ b/build-wrapper.sh
@@ -18,6 +18,7 @@ export HOSTNAME
 export USER='jenkins'
 readonly HERA_HOME=${HERA_HOME:-"${WORKSPACE}/hera/"}
 readonly FAIL_TO_SET_DEFAULT_TO_WORKSPACE_CODE='13'
+readonly COPY_ARTIFACTS=${COPY_ARTIFACTS:-$(if [[ "${BUILD_COMMAND}" = "testsuite" ]]; then echo "true"; fi)}
 
 echo "WORKSPACE: ${WORKSPACE}"
 echo "HERA_HOME: ${HERA_HOME}"
@@ -44,7 +45,7 @@ if [ -n "${HARMONIA_SCRIPT}" ]; then
   is_defined "${HARMONIA_HOME}" 'HARMONIA_HOME is undefined'
   is_dir "${HARMONIA_HOME}" "Provided HARMONIA_HOME is invalid: ${HARMONIA_HOME}"
 
-  if [ "${BUILD_COMMAND}" = 'testsuite' ]; then
+  if [ "${COPY_ARTIFACTS}" = 'true' ]; then
     is_dir "${PARENT_JOB_DIR}"
     copy_artefact_from_parent_job "${PARENT_JOB_DIR}/workdir" "${WORKSPACE}"
   fi

--- a/job.sh
+++ b/job.sh
@@ -40,6 +40,7 @@ run_ssh "podman exec \
         -e MAVEN_GOALS='"${MAVEN_GOALS}"' \
         -e BUILD_ID="${BUILD_ID}" \
         -e BUILD_COMMAND="${BUILD_COMMAND}" \
+        -e COPY_ARTIFACTS="${COPY_ARTIFACTS}" \
         -e RERUN_FAILING_TESTS="${RERUN_FAILING_TESTS}" \
         -e MAVEN_SETTINGS_XML="${MAVEN_SETTINGS_XML}" \
         -e PULL_REQUEST_PROCESSOR_HOME="${PULL_REQUEST_PROCESSOR_HOME}" \


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-358

This PR tries to add an environment called `COPY_ARTIFACTS` to be able to use the facility `copy_artefact_from_parent_job` in Cryo's job.

With this change, we don't need to install `Copy Artifact Plugin` on Olympus.
