### PR TITLE
add 'instance' to /etc/hosts for molecule run

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -105,6 +105,7 @@ readonly CONTAINER_COMMAND=${CONTAINER_COMMAND:-"${WORKSPACE}/hera/wait.sh"}
 run_ssh "podman run \
             --name "${CONTAINER_TO_RUN_NAME}" $(container_user_if_enabled) \
             --add-host=${CONTAINER_SERVER_HOSTNAME}:${CONTAINER_SERVER_IP}  \
+            --add-host=instance:127.0.0.1  \
             --rm $(add_parent_volume_if_provided) $(privileged_if_enabled) $(systemd_if_enabled) $(cgroup_mount_if_enabled) $(add_jenkins_jobs_volume_if_requested) \
             --workdir ${WORKSPACE} $(add_ports_if_provided) \
             -v "${JOB_DIR}":${WORKSPACE}:rw $(mount_tools_if_provided)\


### PR DESCRIPTION
@spyrkob FYI, this is to ensure "instance" is defined for molecule run. We did not need it until now, but with AMQ Streams, there is a few component binding against this name.